### PR TITLE
add weights for theory uncertainties

### DIFF
--- a/plugins/RazorTuplizer.h
+++ b/plugins/RazorTuplizer.h
@@ -47,6 +47,7 @@ using namespace std;
 #include "DataFormats/METReco/interface/HcalNoiseSummary.h"
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
@@ -54,6 +55,7 @@ using namespace std;
 #include "SUSYBSMAnalysis/RazorTuplizer/interface/ElectronMVAEstimatorRun2NonTrig.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include "SUSYBSMAnalysis/RazorTuplizer/interface/EGammaMvaPhotonEstimator.h"
+// #include "PhysicsTools/HepMCCandAlgos/interface/PDFWeightsHelper.h"
 
 //ROOT includes
 #include "TTree.h"
@@ -145,6 +147,7 @@ public:
 
 protected:
   virtual void beginJob() override;
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void endJob() override;
 
@@ -198,6 +201,8 @@ protected:
   edm::EDGetTokenT<bool> hbheNoiseFilterToken_;
   edm::EDGetTokenT<bool> hbheTightNoiseFilterToken_;
   edm::EDGetTokenT<bool> hbheIsoNoiseFilterToken_;
+  edm::InputTag lheRunInfoTag_;
+  edm::EDGetTokenT<LHERunInfoProduct> lheRunInfoToken_;
   edm::EDGetTokenT<LHEEventProduct> lheInfoToken_;
   edm::EDGetTokenT<GenEventInfoProduct> genInfoToken_;
   edm::EDGetTokenT<std::vector<PileupSummaryInfo> > puInfoToken_;
@@ -221,6 +226,7 @@ protected:
   edm::EDGetTokenT<vector<reco::PhotonCore> > gedPhotonCoresToken_;
   edm::EDGetTokenT<vector<reco::SuperCluster> > superClustersToken_;
   edm::EDGetTokenT<vector<pat::PackedCandidate> > lostTracksToken_;
+  
   
   //EDM handles for each miniAOD input object
   edm::Handle<edm::TriggerResults> triggerBits;
@@ -273,6 +279,10 @@ protected:
   //output tree
   TTree *RazorEvents;
   TH1F *NEvents;
+  TH1D *sumWeights;
+  TH1D *sumScaleWeights;
+  TH1D *sumPdfWeights;
+  TH1D *sumAlphasWeights;
 
   //------ Variables for tree ------//
 
@@ -517,7 +527,15 @@ protected:
   float genAlphaQCD;
   float genAlphaQED;
   vector<string> *lheComments;
+  vector<float> *scaleWeights;
+  vector<float> *pdfWeights;
+  vector<float> *alphasWeights;
 
+  int firstPdfWeight;
+  int lastPdfWeight;
+  int firstAlphasWeight;
+  int lastAlphasWeight;
+  
   //gen info
   int nGenParticle;
   int gParticleMotherId[GENPARTICLEARRAYSIZE];
@@ -553,6 +571,9 @@ protected:
   vector<string>  *nameHLT;
   bool triggerDecision[NTriggersMAX];
   int  triggerHLTPrescale[NTriggersMAX];
+  
+  //pdf weight helper
+//   PDFWeightsHelper pdfweightshelper;
 
 };
 


### PR DESCRIPTION
This pull request adds three things

1) per-event weights for factorization/renormalization scale, pdf, and alphas (NLO samples only) uncertainties

2) additional histograms keeping track of sum of nominal gen weight, and sum of all alternate weights.  This is needed in order to factorize acceptance/shape vs cross section uncertainties later.

3) Previously events with no good vertex are skipped.  Now they are kept in order to allow proper acceptance studies downstream.  Please add nPV>0 requirement to downstream analyzers where needed.

Some comments on the usage.  First there is some not super-robust code to automatically figure out which pdf/alphas weights to fill based on the lhe header.  This is tested for existing susy signal, LO madgraph, NLO madgraph_aMC@NLO and NLO powheg samples from the Run 2 production, but it could break for future samples and will eventually need to be revisited (but adequate for now).

To evaluate uncertainties simply use the alternate weights instead of the nominal gen weight to compute a given observable/acceptance/extrapolation factor/histogram/etc.
If you want to evaluate shape/acceptance/cross section variations all correlated together (as for exclusion curves), then the normalization should still be lumi*xsec/sum(nominal weight)

If instead you want to evaluate ONLY the shape/acceptance uncertainty, as when putting a limit on a specific cross section value, then the observable should instead be evaluated renormalizing the MC as lumi*xsec/sum(alternate weight), which imposes the constraint that the overall xsec is not changing.

To evaluate the scale uncertainty, you want to take the envelope for scaleWeights 1,2,3,4,6,8
(0 is just the nominal scale, and 5 and 7 are the "disallowed" 0.5/2 and 2/0.5 renormalization/factorization scale variations)

To evaluate the pdf uncertainties, evaluate the observable for all 100 of the weights and take the rms.

To evaluate the alphas uncertainty, take the difference between the observable computed for the two  weights if they are present and either divide by two, or form an asymmetric uncertainty with the nominal.  The alphas uncertainty can be added in quadrature with the pdf uncertainty (or as an independent nuisance parameter).  Note that this can only be evaluated for NLO samples at the moment.

I'll discuss further with Dustin to get the downstream code implemented for what concerns the signal uncertainties.
