### PR TITLE
Fix for conversion selection sync in mva vertex selection

### DIFF
--- a/plugins/RazorTuplizer.cc
+++ b/plugins/RazorTuplizer.cc
@@ -1765,7 +1765,9 @@ bool RazorTuplizer::fillPhotons(const edm::Event& iEvent, const edm::EventSetup&
     
     //matched conversion, compute conversion type
     //and extrapolation to beamline
-    if (convmatch) {
+    //*FIXME* Both of these additional two requirements are inconsistent and make the conversion
+    //selection depend on poorly defined criteria, but we keep them for sync purposes
+    if (convmatch && pho.hasConversionTracks() && conversions->size()>0) {
       int ntracks = convmatch->nTracks();
       
       math::XYZVector mom(ntracks==2 ? convmatch->refittedPairMomentum() : convmatch->tracksPin()[0]);      


### PR DESCRIPTION
But note that the additional requirements are poorly defined, allow volunteers, and are kind of bugged.  Net effect is some partly random/poorly defined inefficiency for selecting conversions in the mva vertex selection.  Largely irrelevant for this analysis beyond synchronization purposes at least.
